### PR TITLE
Make compatible with Boot-2.0

### DIFF
--- a/aggregator-app-dependencies/pom.xml
+++ b/aggregator-app-dependencies/pom.xml
@@ -19,7 +19,7 @@
 	<description>Spring Cloud Stream Aggregator App Dependencies</description>
 
 	<properties>
-		<spring-boot-geode.version>1.0.0.BUILD-SNAPSHOT</spring-boot-geode.version>
+		<!--TODO <spring-boot-geode.version>1.0.0.BUILD-SNAPSHOT</spring-boot-geode.version>-->
 		<log4j2.version>2.8.2</log4j2.version>
 	</properties>
 
@@ -49,11 +49,14 @@
 				<artifactId>spring-cloud-starter-stream-processor-aggregator</artifactId>
 				<version>2.0.0.BUILD-SNAPSHOT</version>
 			</dependency>
+
+			<!--TODO
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>geode-spring-boot-starter</artifactId>
 				<version>${spring-boot-geode.version}</version>
-			</dependency>
+			</dependency>-->
+
 		</dependencies>
 	</dependencyManagement>
 

--- a/aggregator-app-dependencies/pom.xml
+++ b/aggregator-app-dependencies/pom.xml
@@ -19,20 +19,40 @@
 	<description>Spring Cloud Stream Aggregator App Dependencies</description>
 
 	<properties>
-		<gemfire.version>8.2.3</gemfire.version>
+		<spring-boot-geode.version>1.0.0.BUILD-SNAPSHOT</spring-boot-geode.version>
+		<log4j2.version>2.8.2</log4j2.version>
 	</properties>
 
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-to-slf4j</artifactId>
+				<version>${log4j2.version}</version>
+				<scope>provided</scope>
+			</dependency>
+
+			<!-- Downgrades log4j/slf4 because of Gemfire/Geode hardcoded dependencies -->
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-core</artifactId>
+				<version>${log4j2.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-api</artifactId>
+				<version>${log4j2.version}</version>
+			</dependency>
+
 			<dependency>
 				<groupId>org.springframework.cloud.stream.app</groupId>
 				<artifactId>spring-cloud-starter-stream-processor-aggregator</artifactId>
 				<version>2.0.0.BUILD-SNAPSHOT</version>
 			</dependency>
 			<dependency>
-				<groupId>com.gemstone.gemfire</groupId>
-				<artifactId>gemfire</artifactId>
-				<version>${gemfire.version}</version>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>geode-spring-boot-starter</artifactId>
+				<version>${spring-boot-geode.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,6 @@
 			<id>spring</id>
 			<repositories>
 				<repository>
-					<id>gemstone-release-cache</id>
-					<name>Gemfire Release Repository</name>
-					<url>http://repo.spring.io/gemstone-release-cache</url>
-				</repository>
-				<repository>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>
 					<url>http://repo.spring.io/libs-snapshot-local</url>

--- a/spring-cloud-starter-stream-processor-aggregator/README.adoc
+++ b/spring-cloud-starter-stream-processor-aggregator/README.adoc
@@ -42,43 +42,45 @@ $$aggregator.message-store-type$$:: $$Message store type$$ *($$String$$, default
 $$aggregator.release$$:: $$SpEL expression for release strategy. Default is based on the sequenceSize header$$ *($$Expression$$, default: `$$<none>$$`)*
 $$spring.data.mongodb.authentication-database$$:: $$Authentication database name.$$ *($$String$$, default: `$$<none>$$`)*
 $$spring.data.mongodb.database$$:: $$Database name.$$ *($$String$$, default: `$$<none>$$`)*
-$$spring.data.mongodb.field-naming-strategy$$:: $$Fully qualified name of the FieldNamingStrategy to use.$$ *($$java.lang.Class<?>$$, default: `$$<none>$$`)*
+$$spring.data.mongodb.field-naming-strategy$$:: $$Fully qualified name of the FieldNamingStrategy to use.$$ *($$Class<?>$$, default: `$$<none>$$`)*
 $$spring.data.mongodb.grid-fs-database$$:: $$GridFS database name.$$ *($$String$$, default: `$$<none>$$`)*
-$$spring.data.mongodb.host$$:: $$Mongo server host. Cannot be set with uri.$$ *($$String$$, default: `$$<none>$$`)*
-$$spring.data.mongodb.password$$:: $$Login password of the mongo server. Cannot be set with uri.$$ *($$char[]$$, default: `$$<none>$$`)*
-$$spring.data.mongodb.port$$:: $$Mongo server port. Cannot be set with uri.$$ *($$Integer$$, default: `$$<none>$$`)*
-$$spring.data.mongodb.uri$$:: $$Mongo database URI. Cannot be set with host, port and credentials.$$ *($$String$$, default: `$$<none>$$`)*
-$$spring.data.mongodb.username$$:: $$Login user of the mongo server. Cannot be set with uri.$$ *($$String$$, default: `$$<none>$$`)*
-$$spring.datasource.continue-on-error$$:: $$Do not stop if an error occurs while initializing the database.$$ *($$Boolean$$, default: `$$false$$`)*
-$$spring.datasource.data$$:: $$Data (DML) script resource references.$$ *($$java.util.List<java.lang.String>$$, default: `$$<none>$$`)*
-$$spring.datasource.data-password$$:: $$Password of the database to execute DML scripts.$$ *($$String$$, default: `$$<none>$$`)*
-$$spring.datasource.data-username$$:: $$User of the database to execute DML scripts.$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.data.mongodb.host$$:: $$Mongo server host. Cannot be set with URI.$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.data.mongodb.password$$:: $$Login password of the mongo server. Cannot be set with URI.$$ *($$Character[]$$, default: `$$<none>$$`)*
+$$spring.data.mongodb.port$$:: $$Mongo server port. Cannot be set with URI.$$ *($$Integer$$, default: `$$<none>$$`)*
+$$spring.data.mongodb.uri$$:: $$Mongo database URI. Cannot be set with host, port and credentials.$$ *($$String$$, default: `$$mongodb://localhost/test$$`)*
+$$spring.data.mongodb.username$$:: $$Login user of the mongo server. Cannot be set with URI.$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.datasource.continue-on-error$$:: $$Whether to stop if an error occurs while initializing the database.$$ *($$Boolean$$, default: `$$false$$`)*
+$$spring.datasource.data$$:: $$Data (DML) script resource references.$$ *($$List<String>$$, default: `$$<none>$$`)*
+$$spring.datasource.data-password$$:: $$Password of the database to execute DML scripts (if different).$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.datasource.data-username$$:: $$Username of the database to execute DML scripts (if different).$$ *($$String$$, default: `$$<none>$$`)*
 $$spring.datasource.driver-class-name$$:: $$Fully qualified name of the JDBC driver. Auto-detected based on the URL by default.$$ *($$String$$, default: `$$<none>$$`)*
-$$spring.datasource.generate-unique-name$$:: $$Generate a random datasource name.$$ *($$Boolean$$, default: `$$false$$`)*
-$$spring.datasource.initialize$$:: $$Populate the database using 'data.sql'.$$ *($$Boolean$$, default: `$$true$$`)*
+$$spring.datasource.generate-unique-name$$:: $$Whether to generate a random datasource name.$$ *($$Boolean$$, default: `$$false$$`)*
+$$spring.datasource.initialization-mode$$:: $$Initialize the datasource with available DDL and DML scripts.$$ *($$DataSourceInitializationMode$$, default: `$$embedded$$`, possible values: `ALWAYS`,`EMBEDDED`,`NEVER`)*
 $$spring.datasource.jndi-name$$:: $$JNDI location of the datasource. Class, url, username & password are ignored when
  set.$$ *($$String$$, default: `$$<none>$$`)*
-$$spring.datasource.name$$:: $$Name of the datasource.$$ *($$String$$, default: `$$testdb$$`)*
+$$spring.datasource.name$$:: $$Name of the datasource. Default to "testdb" when using an embedded database.$$ *($$String$$, default: `$$<none>$$`)*
 $$spring.datasource.password$$:: $$Login password of the database.$$ *($$String$$, default: `$$<none>$$`)*
-$$spring.datasource.platform$$:: $$Platform to use in the schema resource (schema-${platform}.sql).$$ *($$String$$, default: `$$all$$`)*
-$$spring.datasource.schema$$:: $$Schema (DDL) script resource references.$$ *($$java.util.List<java.lang.String>$$, default: `$$<none>$$`)*
+$$spring.datasource.platform$$:: $$Platform to use in the DDL or DML scripts (such as schema-${platform}.sql or
+ data-${platform}.sql).$$ *($$String$$, default: `$$all$$`)*
+$$spring.datasource.schema$$:: $$Schema (DDL) script resource references.$$ *($$List<String>$$, default: `$$<none>$$`)*
 $$spring.datasource.schema-password$$:: $$Password of the database to execute DDL scripts (if different).$$ *($$String$$, default: `$$<none>$$`)*
-$$spring.datasource.schema-username$$:: $$User of the database to execute DDL scripts (if different).$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.datasource.schema-username$$:: $$Username of the database to execute DDL scripts (if different).$$ *($$String$$, default: `$$<none>$$`)*
 $$spring.datasource.separator$$:: $$Statement separator in SQL initialization scripts.$$ *($$String$$, default: `$$;$$`)*
 $$spring.datasource.sql-script-encoding$$:: $$SQL scripts encoding.$$ *($$Charset$$, default: `$$<none>$$`)*
 $$spring.datasource.type$$:: $$Fully qualified name of the connection pool implementation to use. By default, it
- is auto-detected from the classpath.$$ *($$java.lang.Class<? extends javax.sql.DataSource>$$, default: `$$<none>$$`)*
-$$spring.datasource.url$$:: $$JDBC url of the database.$$ *($$String$$, default: `$$<none>$$`)*
-$$spring.datasource.username$$:: $$Login user of the database.$$ *($$String$$, default: `$$<none>$$`)*
-$$spring.mongodb.embedded.features$$:: $$Comma-separated list of features to enable.$$ *($$java.util.Set<de.flapdoodle.embed.mongo.distribution.Feature>$$, default: `$$<none>$$`)*
+ is auto-detected from the classpath.$$ *($$Class<DataSource>$$, default: `$$<none>$$`)*
+$$spring.datasource.url$$:: $$JDBC URL of the database.$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.datasource.username$$:: $$Login username of the database.$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.mongodb.embedded.features$$:: $$Comma-separated list of features to enable.$$ *($$Set<Feature>$$, default: `$$[sync_delay]$$`)*
 $$spring.mongodb.embedded.version$$:: $$Version of Mongo to use.$$ *($$String$$, default: `$$3.2.2$$`)*
 $$spring.redis.database$$:: $$Database index used by the connection factory.$$ *($$Integer$$, default: `$$0$$`)*
 $$spring.redis.host$$:: $$Redis server host.$$ *($$String$$, default: `$$localhost$$`)*
 $$spring.redis.password$$:: $$Login password of the redis server.$$ *($$String$$, default: `$$<none>$$`)*
 $$spring.redis.port$$:: $$Redis server port.$$ *($$Integer$$, default: `$$6379$$`)*
-$$spring.redis.ssl$$:: $$Enable SSL.$$ *($$Boolean$$, default: `$$false$$`)*
-$$spring.redis.timeout$$:: $$Connection timeout in milliseconds.$$ *($$Integer$$, default: `$$0$$`)*
-$$spring.redis.url$$:: $$Redis url, which will overrule host, port and password if set.$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.redis.ssl$$:: $$Whether to enable SSL support.$$ *($$Boolean$$, default: `$$false$$`)*
+$$spring.redis.timeout$$:: $$Connection timeout.$$ *($$Duration$$, default: `$$<none>$$`)*
+$$spring.redis.url$$:: $$Connection URL. Overrides host, port, and password. User is ignored. Example:
+ redis://user:password@example.com:6379$$ *($$String$$, default: `$$<none>$$`)*
 //end::configuration-properties[]
 
 By default the `aggregator` processor uses:

--- a/spring-cloud-starter-stream-processor-aggregator/pom.xml
+++ b/spring-cloud-starter-stream-processor-aggregator/pom.xml
@@ -72,10 +72,17 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+
+		<!--TODO-->
 		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-geode</artifactId>
+		</dependency>
+
+		<!--<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>geode-spring-boot-starter</artifactId>
-		</dependency>
+		</dependency>-->
 
 		<dependency>
 			<groupId>org.springframework.integration</groupId>

--- a/spring-cloud-starter-stream-processor-aggregator/pom.xml
+++ b/spring-cloud-starter-stream-processor-aggregator/pom.xml
@@ -16,6 +16,27 @@
 	<description>Spring Cloud Stream Aggregator Processor Starter</description>
 
 	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-logging</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-to-slf4j</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-mongodb</artifactId>
@@ -46,15 +67,14 @@
 			<artifactId>spring-integration-gemfire</artifactId>
 			<exclusions>
 				<exclusion>
-					<groupId>com.gemstone.gemfire</groupId>
-					<artifactId>gemfire</artifactId>
+					<groupId>org.springframework.data</groupId>
+					<artifactId>spring-data-gemfire</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
-
 		<dependency>
-			<groupId>com.gemstone.gemfire</groupId>
-			<artifactId>gemfire</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>geode-spring-boot-starter</artifactId>
 		</dependency>
 
 		<dependency>
@@ -107,20 +127,8 @@
 						<version>${project.version}</version>
 					</bom>
 					<generatedApps>
-						<aggregator-processor>
-							<extraRepositories>
-								<gemstone-release-pivotal />
-							</extraRepositories>
-						</aggregator-processor>
+						<aggregator-processor/>
 					</generatedApps>
-					<extraRepositories>
-						<repository>
-							<id>gemstone-release-pivotal</id>
-							<url>http://repo.spring.io/gemstone-release-pivotal</url>
-							<name>Gemfire Release Repository</name>
-							<snapshotEnabled>false</snapshotEnabled>
-						</repository>
-					</extraRepositories>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/spring-cloud-starter-stream-processor-aggregator/src/main/java/org/springframework/cloud/stream/app/aggregator/processor/AggregatorProcessorConfiguration.java
+++ b/spring-cloud-starter-stream-processor-aggregator/src/main/java/org/springframework/cloud/stream/app/aggregator/processor/AggregatorProcessorConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ public class AggregatorProcessorConfiguration {
 	@ConditionalOnProperty(prefix = AggregatorProperties.PREFIX, name = "release")
 	@ConditionalOnMissingBean
 	public ReleaseStrategy releaseStrategy() {
-		return new ExpressionEvaluatingReleaseStrategy(this.properties.getRelease().getExpressionString());
+		return new ExpressionEvaluatingReleaseStrategy(this.properties.getRelease());
 	}
 
 	@Bean

--- a/spring-cloud-starter-stream-processor-aggregator/src/main/java/org/springframework/cloud/stream/app/aggregator/processor/ClientCacheAutoConfiguration.java
+++ b/spring-cloud-starter-stream-processor-aggregator/src/main/java/org/springframework/cloud/stream/app/aggregator/processor/ClientCacheAutoConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.app.aggregator.processor;
+
+import org.apache.geode.cache.GemFireCache;
+import org.apache.geode.cache.client.ClientCache;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.gemfire.client.ClientCacheFactoryBean;
+import org.springframework.data.gemfire.config.annotation.ClientCacheApplication;
+import org.springframework.data.gemfire.config.annotation.EnablePdx;
+
+/**
+ * TODO
+ *
+ * This is the copy of {@code org.springframework.boot.data.geode.autoconfigure.ClientCacheAutoConfiguration}
+ * until {@code geode-spring-boot-starter} is released.
+ *
+ * @author John Blum
+ */
+@Configuration
+@ConditionalOnClass({ ClientCacheFactoryBean.class, ClientCache.class })
+@ConditionalOnMissingBean(GemFireCache.class)
+@ClientCacheApplication
+@EnablePdx
+public class ClientCacheAutoConfiguration {
+
+}

--- a/spring-cloud-starter-stream-processor-aggregator/src/main/java/org/springframework/cloud/stream/app/aggregator/processor/ExcludeStoresAutoConfigurationEnvironmentPostProcessor.java
+++ b/spring-cloud-starter-stream-processor-aggregator/src/main/java/org/springframework/cloud/stream/app/aggregator/processor/ExcludeStoresAutoConfigurationEnvironmentPostProcessor.java
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
+import org.springframework.boot.data.geode.autoconfigure.ClientCacheAutoConfiguration;
 import org.springframework.boot.env.EnvironmentPostProcessor;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MutablePropertySources;
@@ -53,6 +54,7 @@ public class ExcludeStoresAutoConfigurationEnvironmentPostProcessor implements E
 						MongoRepositoriesAutoConfiguration.class.getName() + ", " +
 						EmbeddedMongoAutoConfiguration.class.getName() + ", " +
 						RedisAutoConfiguration.class.getName() + ", " +
+						ClientCacheAutoConfiguration.class.getName() + ", " +
 						RedisRepositoriesAutoConfiguration.class.getName());
 
 		propertySources.addLast(

--- a/spring-cloud-starter-stream-processor-aggregator/src/main/java/org/springframework/cloud/stream/app/aggregator/processor/ExcludeStoresAutoConfigurationEnvironmentPostProcessor.java
+++ b/spring-cloud-starter-stream-processor-aggregator/src/main/java/org/springframework/cloud/stream/app/aggregator/processor/ExcludeStoresAutoConfigurationEnvironmentPostProcessor.java
@@ -27,7 +27,9 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
-import org.springframework.boot.data.geode.autoconfigure.ClientCacheAutoConfiguration;
+
+//TODO import org.springframework.boot.data.geode.autoconfigure.ClientCacheAutoConfiguration;
+
 import org.springframework.boot.env.EnvironmentPostProcessor;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MutablePropertySources;

--- a/spring-cloud-starter-stream-processor-aggregator/src/main/java/org/springframework/cloud/stream/app/aggregator/processor/ExcludeStoresAutoConfigurationEnvironmentPostProcessor.java
+++ b/spring-cloud-starter-stream-processor-aggregator/src/main/java/org/springframework/cloud/stream/app/aggregator/processor/ExcludeStoresAutoConfigurationEnvironmentPostProcessor.java
@@ -56,7 +56,7 @@ public class ExcludeStoresAutoConfigurationEnvironmentPostProcessor implements E
 						MongoRepositoriesAutoConfiguration.class.getName() + ", " +
 						EmbeddedMongoAutoConfiguration.class.getName() + ", " +
 						RedisAutoConfiguration.class.getName() + ", " +
-						ClientCacheAutoConfiguration.class.getName() + ", " +
+//					TODO	ClientCacheAutoConfiguration.class.getName() + ", " +
 						RedisRepositoriesAutoConfiguration.class.getName());
 
 		propertySources.addLast(

--- a/spring-cloud-starter-stream-processor-aggregator/src/main/java/org/springframework/cloud/stream/app/aggregator/processor/MessageStoreConfiguration.java
+++ b/spring-cloud-starter-stream-processor-aggregator/src/main/java/org/springframework/cloud/stream/app/aggregator/processor/MessageStoreConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
-import org.springframework.boot.data.geode.autoconfigure.ClientCacheAutoConfiguration;
+//import org.springframework.boot.data.geode.autoconfigure.ClientCacheAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.gemfire.client.ClientRegionFactoryBean;

--- a/spring-cloud-starter-stream-processor-aggregator/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-starter-stream-processor-aggregator/src/main/resources/META-INF/spring.factories
@@ -1,6 +1,2 @@
 org.springframework.boot.env.EnvironmentPostProcessor=\
   org.springframework.cloud.stream.app.aggregator.processor.ExcludeStoresAutoConfigurationEnvironmentPostProcessor
-
-# TODO
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.springframework.cloud.stream.app.aggregator.processor.ClientCacheAutoConfiguration

--- a/spring-cloud-starter-stream-processor-aggregator/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-starter-stream-processor-aggregator/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,6 @@
 org.springframework.boot.env.EnvironmentPostProcessor=\
   org.springframework.cloud.stream.app.aggregator.processor.ExcludeStoresAutoConfigurationEnvironmentPostProcessor
+
+# TODO
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.springframework.cloud.stream.app.aggregator.processor.ClientCacheAutoConfiguration


### PR DESCRIPTION
Related to https://github.com/spring-cloud-stream-app-starters/app-starters-release/issues/134

* Perform appropriate changes for compatibility with the latest SI and Boot
* Change Gemfire dependency to Geode for Open Source Policy compatibility
* Add `geode-spring-boot-starter` dependency for better experience
* Add some dependencies "kung-fu" to make Geode compatible with Spring Boot
* downgrade to Log4J-2.8.2 - the compatible with Geode version
* Exclude `log4j-to-slf4j` which is not compatible with what Geode  uses