### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/spring-cloud-starter-stream-processor-aggregator/README.adoc
+++ b/spring-cloud-starter-stream-processor-aggregator/README.adoc
@@ -3,7 +3,7 @@
 
 Use the `aggregator` application to combine multiple messages into one, based on some correlation mechanism.
 
-This processor is fully based on the Aggregator component from http://docs.spring.io/spring-integration/reference/html/messaging-routing-chapter.html#aggregator[Spring Integration].
+This processor is fully based on the Aggregator component from https://docs.spring.io/spring-integration/reference/html/messaging-routing-chapter.html#aggregator[Spring Integration].
 So, please, consult there for use-cases and functionality.
 
 == Input
@@ -87,11 +87,11 @@ By default the `aggregator` processor uses:
 - `DefaultAggregatingMessageGroupProcessor`  - for `aggregation`;
 - `SimpleMessageStore` - for `messageStoreType`.
 
-The `aggregator` application can be configured for persistent `MessageGroupStore` http://docs.spring.io/spring-integration/reference/html/system-management-chapter.html#message-store[implementations].
+The `aggregator` application can be configured for persistent `MessageGroupStore` https://docs.spring.io/spring-integration/reference/html/system-management-chapter.html#message-store[implementations].
 The configuration for target technology is fully based on the Spring Boot auto-configuration.
 But default JDBC, MongoDb and Redis auto-configurations are excluded.
 They are `@Import` ed basing on the `aggregator.messageStoreType` configuration property.
-Consult Spring Boot http://docs.spring.io/spring-boot/docs/current/reference/html/[Reference Manual] for auto-configuration for particular technology you use for `aggregator`.
+Consult Spring Boot https://docs.spring.io/spring-boot/docs/current/reference/html/[Reference Manual] for auto-configuration for particular technology you use for `aggregator`.
 
 The JDBC `JdbcMessageStore` requires particular tables in the target data base.
 You can find schema scripts for appropriate RDBMS vendors in the `org.springframework.integration.jdbc` package of the `spring-integration-jdbc` jar.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://docs.spring.io/spring-integration/reference/html/messaging-routing-chapter.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-integration/reference/html/messaging-routing-chapter.html ([https](https://docs.spring.io/spring-integration/reference/html/messaging-routing-chapter.html) result 404).
* [ ] http://docs.spring.io/spring-integration/reference/html/system-management-chapter.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-integration/reference/html/system-management-chapter.html ([https](https://docs.spring.io/spring-integration/reference/html/system-management-chapter.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-boot/docs/current/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/html/ ([https](https://docs.spring.io/spring-boot/docs/current/reference/html/) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).